### PR TITLE
Enable Jaeger exporter for the default build

### DIFF
--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -15,7 +15,9 @@ jobs:
         with:
           submodules: 'recursive'
       - name: install packages
-        run: sudo apt install cmake libcurl4-openssl-dev libboost-all-dev
+        run: |
+          sudo apt update
+          sudo apt install cmake libcurl4-openssl-dev libboost-all-dev
       - name: build deps
         run: |
           mkdir -p $HOME/splunk-otel-cpp

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -27,6 +27,7 @@ jobs:
           cmake -DCMAKE_INSTALL_PREFIX=$HOME/splunk-otel-cpp \
             -DCMAKE_PREFIX_PATH=$HOME/splunk-otel-cpp \
             -DSPLUNK_CPP_WITH_JAEGER_EXPORTER=ON \
+            -DSPLUNK_CPP_TESTS=ON \
             ..
           make install
       - name: Spin up collector image

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,9 @@ set(PACKAGE_VERSION "0.1.0")
 
 set(CMAKE_CXX_STANDARD 11)
 
-option(SPLUNK_CPP_TESTS "Enable building of tests" ON)
+option(SPLUNK_CPP_TESTS "Enable building of tests" OFF)
 option(SPLUNK_CPP_EXAMPLES "Enable building of examples" ON)
-option(SPLUNK_CPP_WITH_JAEGER_EXPORTER "Enable Jaeger exporter" OFF)
+option(SPLUNK_CPP_WITH_JAEGER_EXPORTER "Enable Jaeger exporter" ON)
 
 find_package(Protobuf REQUIRED)
 find_package(gRPC REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ if (SPLUNK_CPP_WITH_JAEGER_EXPORTER)
   set(SPLUNK_CPP_JAEGER_EXPORTER_LIBS
     CURL::libcurl
     thrift::thrift)
+else()
+  find_package(CURL)
 endif()
 
 add_library(SplunkOpenTelemetry

--- a/SplunkOpenTelemetryConfig.cmake.in
+++ b/SplunkOpenTelemetryConfig.cmake.in
@@ -17,6 +17,8 @@ set(SPLUNK_CPP_WITH_JAEGER_EXPORTER @SPLUNK_CPP_WITH_JAEGER_EXPORTER@)
 if (SPLUNK_CPP_WITH_JAEGER_EXPORTER)
   find_dependency(Thrift REQUIRED)
   find_dependency(CURL REQUIRED)
+else()
+  find_dependency(CURL)
 endif()
 
 set_and_check(SplunkOpenTelemetry_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")

--- a/docker/build_splunk_distro
+++ b/docker/build_splunk_distro
@@ -9,6 +9,7 @@ cmake -DCMAKE_PREFIX_PATH=/splunk-cpp-distro \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DSPLUNK_CPP_TESTS=OFF \
   -DSPLUNK_CPP_EXAMPLES=OFF \
+  -DSPLUNK_CPP_WITH_JAEGER_EXPORTER=OFF \
   -DCMAKE_BUILD_TYPE=Release \
   /splunk-otel-cpp
 make -j$(nproc)


### PR DESCRIPTION
This was causing CMake configuration issues due to `build_deps.sh` enabling Jaeger for OpenTelemetry CPP which wants to link against it, but `find_package` was missing for both Thrift and CURL.