### PR TITLE
Upgrade to OpenTelemetry 1.0.0, add Conan recipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5.1)
 
-project(SplunkOpenTelemetry)
+project(SplunkOpenTelemetry CXX)
 
 include(CMakePackageConfigHelpers)
 
@@ -15,7 +15,6 @@ option(SPLUNK_CPP_WITH_JAEGER_EXPORTER "Enable Jaeger exporter" ON)
 find_package(Protobuf REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(opentelemetry-cpp REQUIRED)
-find_package(absl REQUIRED)
 find_package(nlohmann_json REQUIRED)
 if (SPLUNK_CPP_WITH_JAEGER_EXPORTER)
   find_package(CURL REQUIRED)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ git clone --recurse-submodules https://github.com/signalfx/splunk-otel-cpp.git
 $ ./build_deps.sh -DCMAKE_INSTALL_PREFIX=/path/to/splunk-otel-cpp-install
 $ mkdir build
 $ cd build
-$ cmake -DCMAKE_INSTALL_PREFIX=/path/to/splunk-otel-cpp-install -DCMAKE_PREFIX_PATH=/path/to/splunk-otel-cpp-install ..
+$ cmake -DCMAKE_INSTALL_PREFIX=/path/to/splunk-otel-cpp-install ..
 $ make install
 ```
 

--- a/SplunkOpenTelemetryConfig.cmake.in
+++ b/SplunkOpenTelemetryConfig.cmake.in
@@ -10,7 +10,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(Protobuf REQUIRED)
 find_dependency(gRPC REQUIRED)
 find_dependency(opentelemetry-cpp REQUIRED)
-find_dependency(absl REQUIRED)
 find_dependency(nlohmann_json REQUIRED)
 
 set(SPLUNK_CPP_WITH_JAEGER_EXPORTER @SPLUNK_CPP_WITH_JAEGER_EXPORTER@)

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -1,10 +1,7 @@
 set -ex
 
-mkdir -p third_party
-
 BUILD_TYPE=Release
 ROOT_DIR=$(pwd)
-THIRD_PARTY_DIR=${ROOT_DIR}/third_party
 
 mkdir -p ${ROOT_DIR}/grpc/build
 cd ${ROOT_DIR}/grpc/build
@@ -57,11 +54,10 @@ mkdir -p ${ROOT_DIR}/opentelemetry-cpp/build
 cd ${ROOT_DIR}/opentelemetry-cpp/build
 cmake \
   -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-  -DCMAKE_PREFIX_PATH=${THIRD_PARTY_DIR} \
   -DWITH_OTLP=ON \
   -DWITH_OTLP_HTTP=OFF \
   -DWITH_JAEGER=ON \
-  -DWITH_ABSEIL=ON \
+  -DWITH_ABSEIL=OFF \
   -DBUILD_TESTING=OFF \
   -DWITH_EXAMPLES=OFF \
   "$@" \

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,8 +11,6 @@ class SplunkOpentelemetryConan(ConanFile):
     description = "Splunk's distribution of OpenTelemetry C++"
     topics = ("opentelemetry", "observability", "tracing")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"fPIC": [True, False]}
-    default_options = {"fPIC": True}
     generators = "cmake_find_package"
     requires = "grpc/1.37.1", "protobuf/3.17.1", "libcurl/7.79.1"
     exports_sources = [
@@ -23,10 +21,6 @@ class SplunkOpentelemetryConan(ConanFile):
       "SplunkOpenTelemetryConfig.cmake.in"
     ]
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
     def _build_otel_cpp(self):
       cmake = CMake(self)
       prefix_paths = [
@@ -35,9 +29,7 @@ class SplunkOpentelemetryConan(ConanFile):
       ]
 
       defs = {
-        'CMAKE_BUILD_TYPE': 'Release',
         'CMAKE_PREFIX_PATH': ';'.join(prefix_paths),
-        'CMAKE_POSITION_INDEPENDENT_CODE': True,
         'WITH_OTLP': True,
         'WITH_OTLP_HTTP': False,
         'WITH_JAEGER': False,
@@ -53,8 +45,6 @@ class SplunkOpentelemetryConan(ConanFile):
         self._build_otel_cpp()
         cmake = CMake(self)
         defs = {
-          'CMAKE_BUILD_TYPE': 'Release',
-          'CMAKE_POSITION_INDEPENDENT_CODE': True,
           'SPLUNK_CPP_WITH_JAEGER_EXPORTER': False,
           'SPLUNK_CPP_EXAMPLES': False,
         }

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,91 @@
+from conans import ConanFile, CMake
+import os
+
+
+class SplunkOpentelemetryConan(ConanFile):
+    name = "splunk-opentelemetry"
+    version = "0.1"
+    license = "Apache 2.0"
+    author = "Splunk"
+    url = "https://github.com/signalfx/splunk-otel-cpp"
+    description = "Splunk's distribution of OpenTelemetry C++"
+    topics = ("opentelemetry", "observability", "tracing")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"fPIC": [True, False]}
+    default_options = {"fPIC": True}
+    generators = "cmake_find_package"
+    requires = "grpc/1.37.1", "protobuf/3.17.1", "libcurl/7.79.1"
+    exports_sources = [
+      "src*",
+      "include*",
+      "opentelemetry-cpp*",
+      "CMakeLists.txt",
+      "SplunkOpenTelemetryConfig.cmake.in"
+    ]
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def _build_otel_cpp(self):
+      cmake = CMake(self)
+      prefix_paths = [
+        self.deps_cpp_info['grpc'].rootpath,
+        self.deps_cpp_info['protobuf'].rootpath,
+      ]
+
+      defs = {
+        'CMAKE_BUILD_TYPE': 'Release',
+        'CMAKE_PREFIX_PATH': ';'.join(prefix_paths),
+        'CMAKE_POSITION_INDEPENDENT_CODE': True,
+        'WITH_OTLP': True,
+        'WITH_OTLP_HTTP': False,
+        'WITH_JAEGER': False,
+        'WITH_ABSEIL': False,
+        'BUILD_TESTING': False,
+        'WITH_EXAMPLES': False
+      }
+      cmake.configure(source_folder="opentelemetry-cpp", defs=defs, build_folder='otelcpp_build')
+      cmake.build()
+      cmake.install()
+
+    def build(self):
+        self._build_otel_cpp()
+        cmake = CMake(self)
+        defs = {
+          'CMAKE_BUILD_TYPE': 'Release',
+          'CMAKE_POSITION_INDEPENDENT_CODE': True,
+          'SPLUNK_CPP_WITH_JAEGER_EXPORTER': False,
+          'SPLUNK_CPP_EXAMPLES': False,
+        }
+        cmake.configure(source_folder=".", defs=defs)
+        cmake.build()
+        cmake.install()
+
+    def package(self):
+        self.copy("*.h", dst="include", src="src")
+        self.copy("*.a", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.components["opentelemetry-cpp"].requires = [
+          "grpc::grpc",
+          "protobuf::protobuf",
+          "libcurl::libcurl"
+        ]
+        self.cpp_info.components["opentelemetry-cpp"].libs = [
+          "libhttp_client_curl",
+          "libopentelemetry_common",
+          "libopentelemetry_exporter_ostream_span",
+          "libopentelemetry_proto",
+          "libopentelemetry_otlp_recordable",
+          "libopentelemetry_exporter_otlp_grpc",
+          "libopentelemetry_resources",
+          "libopentelemetry_trace",
+          "libopentelemetry_version",
+          "libopentelemetry_zpages"
+        ]
+
+        self.cpp_info.components["SplunkOpenTelemetry"].requires = ["opentelemetry-cpp"]
+        self.cpp_info.components["SplunkOpenTelemetry"].libs = [
+          "libSplunkOpenTelemetry"
+        ]

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -37,7 +37,7 @@ RUN cd /grpc/third_party/abseil-cpp \
   && make -j$(nproc) \
   && make install
 
-RUN git clone --depth 1 --recurse-submodules -b v1.0.0-rc4 https://github.com/open-telemetry/opentelemetry-cpp
+RUN git clone --depth 1 --recurse-submodules -b v1.0.0 https://github.com/open-telemetry/opentelemetry-cpp
 
 RUN cd /opentelemetry-cpp \
   && mkdir -p build \
@@ -47,7 +47,7 @@ RUN cd /opentelemetry-cpp \
     -DWITH_OTLP=ON \
     -DWITH_OTLP_HTTP=OFF \
     -DWITH_JAEGER=OFF \
-    -DWITH_ABSEIL=ON \
+    -DWITH_ABSEIL=OFF \
     -DBUILD_TESTING=OFF \
     -DWITH_EXAMPLES=OFF \
     -DCMAKE_PREFIX_PATH=/splunk-cpp-distro \

--- a/examples/http_client.cpp
+++ b/examples/http_client.cpp
@@ -5,8 +5,8 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <opentelemetry/context/propagation/global_propagator.h>
 #include <splunk/opentelemetry.h>
+#include <opentelemetry/context/propagation/global_propagator.h>
 #include <string>
 
 #include "http_common.h"

--- a/examples/http_server.cpp
+++ b/examples/http_server.cpp
@@ -5,9 +5,9 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <opentelemetry/context/propagation/global_propagator.h>
-#include <opentelemetry/trace/propagation/detail/context.h>
 #include <splunk/opentelemetry.h>
+#include <opentelemetry/context/propagation/global_propagator.h>
+#include <opentelemetry/trace/context.h>
 #include <string>
 
 #include "http_common.h"
@@ -121,7 +121,7 @@ int main(int argc, char** argv) {
     opentelemetry::trace::StartSpanOptions startOptions;
     startOptions.kind = opentelemetry::trace::SpanKind::kServer;
 
-    auto parentSpan = opentelemetry::trace::propagation::GetSpan(parentContext);
+    auto parentSpan = opentelemetry::trace::GetSpan(parentContext);
 
     startOptions.parent = parentSpan->GetContext();
 

--- a/include/splunk/opentelemetry.h
+++ b/include/splunk/opentelemetry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <opentelemetry/exporters/otlp/otlp_grpc_exporter.h>
 #include <opentelemetry/sdk/resource/resource.h>
 #include <opentelemetry/trace/provider.h>
 #include "splunk_config.h"

--- a/src/opentelemetry.cpp
+++ b/src/opentelemetry.cpp
@@ -3,7 +3,6 @@
 #include <opentelemetry/baggage/propagation/baggage_propagator.h>
 #include <opentelemetry/context/propagation/composite_propagator.h>
 #include <opentelemetry/context/propagation/global_propagator.h>
-#include <opentelemetry/exporters/otlp/otlp_grpc_exporter.h>
 #include <opentelemetry/sdk/trace/batch_span_processor.h>
 #include <opentelemetry/sdk/trace/exporter.h>
 #include <opentelemetry/sdk/trace/tracer_provider.h>


### PR DESCRIPTION
* Add support for Conan package manager. The added `conanfile.py` can be used to create a package, upload it and consume it.
* Upgrade to OpenTelemetry 1.0.0
* Remove `abseil` from required dependencies, OpenTelemetry C++ is now configured with `-DWITH_ABSEIL=OFF`. grpc uses its own abseil. I moved around the includes as written in: https://github.com/open-telemetry/opentelemetry-cpp/blob/b5dd914c9d7a36342a8b9e4d1c014354e983f917/examples/otlp/README.md#additional-notes-regarding-abseil-library to avoid any clashes with OpenTelemetry C++'s included abseil headers.
* Clean up `build_deps.sh`: `third_party` dir was unnecessary.