### PR TITLE
GH actions: fix release action

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -79,9 +79,14 @@ jobs:
         with:
           name: splunk-opentelemetry-cpp-conan
           path: splunk-opentelemetry-cpp.tar.gz
+      - name: prepare-release-file
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          mv splunk-opentelemetry-cpp.tar.gz splunk-opentelemetry-cpp-$GITHUB_REF.tar.gz
       - name: release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: splunk-opentelemetry-cpp-${GITHUB_REF}-conan.tar.gz
-          path: splunk-opentelemetry-cpp.tar.gz
+          draft: true
+          files: |
+            splunk-opentelemetry-cpp-$GITHUB_REF.tar.gz

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, CMake
 
 class SplunkOpentelemetryConan(ConanFile):
     name = "splunk-opentelemetry"
-    version = "0.2"
+    version = "0.3.0"
     license = "Apache 2.0"
     author = "Splunk"
     url = "https://github.com/signalfx/splunk-otel-cpp"


### PR DESCRIPTION
* Fixed the configuration options for `softprops/action-gh-release@v1`
* Upgrade the version in conanfile to 0.3.0 to match tags