### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,5 @@ Note: options passed via `splunk::OpenTelemetryOptions` take preference over env
 The Splunk Distribution of OpenTelemetry C++ is a distribution
 of the [OpenTelemetry C++ project](https://github.com/open-telemetry/opentelemetry-cpp).
 It is released under the terms of the Apache Software License version 2.0. See [the license file](./LICENSE) for more details.
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.